### PR TITLE
Remove certain void return types

### DIFF
--- a/src/Observer/AbstractObserver.php
+++ b/src/Observer/AbstractObserver.php
@@ -38,7 +38,7 @@ abstract class AbstractObserver implements \Magento\Framework\Event\ObserverInte
         $this->contentAttacher = $contentAttacher;
     }
 
-    public function attachContent($content, $pdfFilename, $mimeType, ContainerInterface $attachmentContainer): void
+    public function attachContent($content, $pdfFilename, $mimeType, ContainerInterface $attachmentContainer)
     {
         $this->contentAttacher->addGeneric($content, $pdfFilename, $mimeType, $attachmentContainer);
     }
@@ -50,7 +50,7 @@ abstract class AbstractObserver implements \Magento\Framework\Event\ObserverInte
      *
      * @deprecated see \Fooman\EmailAttachments\Model\ContentAttacher::addPdf()
      */
-    public function attachPdf($pdfString, $pdfFilename, ContainerInterface $attachmentContainer): void
+    public function attachPdf($pdfString, $pdfFilename, ContainerInterface $attachmentContainer)
     {
         $this->contentAttacher->addPdf($pdfString, $pdfFilename, $attachmentContainer);
     }
@@ -62,7 +62,7 @@ abstract class AbstractObserver implements \Magento\Framework\Event\ObserverInte
      *
      * @deprecated see \Fooman\EmailAttachments\Model\ContentAttacher::addText()
      */
-    public function attachTxt($text, $filename, ContainerInterface $attachmentContainer): void
+    public function attachTxt($text, $filename, ContainerInterface $attachmentContainer)
     {
         $this->contentAttacher->addText($text, $filename, $attachmentContainer);
     }
@@ -74,12 +74,12 @@ abstract class AbstractObserver implements \Magento\Framework\Event\ObserverInte
      *
      * @deprecated see \Fooman\EmailAttachments\Model\ContentAttacher::addHtml()
      */
-    public function attachHtml($html, $filename, ContainerInterface $attachmentContainer): void
+    public function attachHtml($html, $filename, ContainerInterface $attachmentContainer)
     {
         $this->contentAttacher->addHtml($html, $filename, $attachmentContainer);
     }
 
-    public function attachTermsAndConditions($storeId, ContainerInterface $attachmentContainer): void
+    public function attachTermsAndConditions($storeId, ContainerInterface $attachmentContainer)
     {
         $this->termsAttacher->attachForStore($storeId, $attachmentContainer);
     }

--- a/src/Plugin/TransportBuilder.php
+++ b/src/Plugin/TransportBuilder.php
@@ -26,14 +26,14 @@ class TransportBuilder
     public function beforeSetTemplateIdentifier(
         \Magento\Framework\Mail\Template\TransportBuilder $subject,
         $templateIdentifier
-    ): void {
+    ) {
         $this->nextEmail->setTemplateIdentifier($templateIdentifier);
     }
 
     public function beforeSetTemplateVars(
         \Magento\Framework\Mail\Template\TransportBuilder $subject,
         $templateVars
-    ): void {
+    ) {
         $this->nextEmail->setTemplateVars($templateVars);
     }
 
@@ -46,7 +46,7 @@ class TransportBuilder
         return $mailTransport;
     }
 
-    private function reset(): void
+    private function reset()
     {
         $this->nextEmail->setTemplateIdentifier(null);
         $this->nextEmail->setTemplateVars(null);


### PR DESCRIPTION
Void return types are breaking Magento 2.2.8 because you shouldn't use void return types in plugins