### PR TITLE
finish void return type cleanup

### DIFF
--- a/src/Observer/AbstractSendCreditmemoObserver.php
+++ b/src/Observer/AbstractSendCreditmemoObserver.php
@@ -16,7 +16,7 @@ class AbstractSendCreditmemoObserver extends AbstractObserver
     const XML_PATH_ATTACH_PDF = 'sales_email/creditmemo/attachpdf';
     const XML_PATH_ATTACH_AGREEMENT = 'sales_email/creditmemo/attachagreement';
 
-    public function execute(\Magento\Framework\Event\Observer $observer): void
+    public function execute(\Magento\Framework\Event\Observer $observer)
     {
         /**
          * @var $creditmemo \Magento\Sales\Api\Data\CreditmemoInterface

--- a/src/Observer/AbstractSendInvoiceObserver.php
+++ b/src/Observer/AbstractSendInvoiceObserver.php
@@ -16,7 +16,7 @@ class AbstractSendInvoiceObserver extends AbstractObserver
     const XML_PATH_ATTACH_PDF = 'sales_email/invoice/attachpdf';
     const XML_PATH_ATTACH_AGREEMENT = 'sales_email/invoice/attachagreement';
 
-    public function execute(\Magento\Framework\Event\Observer $observer): void
+    public function execute(\Magento\Framework\Event\Observer $observer)
     {
         /**
          * @var $invoice \Magento\Sales\Api\Data\InvoiceInterface

--- a/src/Observer/AbstractSendOrderObserver.php
+++ b/src/Observer/AbstractSendOrderObserver.php
@@ -16,7 +16,7 @@ class AbstractSendOrderObserver extends AbstractObserver
     const XML_PATH_ATTACH_PDF = 'sales_email/order/attachpdf';
     const XML_PATH_ATTACH_AGREEMENT = 'sales_email/order/attachagreement';
 
-    public function execute(\Magento\Framework\Event\Observer $observer): void
+    public function execute(\Magento\Framework\Event\Observer $observer)
     {
         /**
          * @var $order \Magento\Sales\Api\Data\OrderInterface

--- a/src/Observer/AbstractSendShipmentObserver.php
+++ b/src/Observer/AbstractSendShipmentObserver.php
@@ -16,7 +16,7 @@ class AbstractSendShipmentObserver extends AbstractObserver
     const XML_PATH_ATTACH_PDF = 'sales_email/shipment/attachpdf';
     const XML_PATH_ATTACH_AGREEMENT = 'sales_email/shipment/attachagreement';
 
-    public function execute(\Magento\Framework\Event\Observer $observer): void
+    public function execute(\Magento\Framework\Event\Observer $observer)
     {
 
         /**


### PR DESCRIPTION
@fooman I found that it was still breaking so I cleaned up the void return types. Maybe later we can add the return void in the PHPDOC instead? What do you think? :)